### PR TITLE
Fix tracing for `WebDriver#getPageSource`

### DIFF
--- a/javascript/webdriver/webdriver.js
+++ b/javascript/webdriver/webdriver.js
@@ -768,7 +768,7 @@ webdriver.WebDriver.prototype.getAllWindowHandles = function() {
 webdriver.WebDriver.prototype.getPageSource = function() {
   return this.schedule(
       new webdriver.Command(webdriver.CommandName.GET_PAGE_SOURCE),
-      'WebDriver.getAllWindowHandles()');
+      'WebDriver.getPageSource()');
 };
 
 


### PR DESCRIPTION
The tracing for sending the `getPageSource` command instead identified the command as `getAllWindowHandles`
